### PR TITLE
Pester

### DIFF
--- a/bin/cask.ps1
+++ b/bin/cask.ps1
@@ -1,0 +1,1 @@
+emacs -Q --batch --script "$env:UserProfile\.cask\cask-cli.el" -- $args

--- a/bin/cask.ps1
+++ b/bin/cask.ps1
@@ -1,1 +1,30 @@
-emacs -Q --batch --script "$env:UserProfile\.cask\cask-cli.el" -- $args
+function Exec-Cask {
+    emacs -Q --batch --script "$Env:UserProfile\.cask\cask-cli.el" -- @args
+}
+
+function Exec-Command($cmd) {
+    $emacsLoadPath = $Env:EMACSLOADPATH
+    $path = $Env:Path
+    try {
+        $Env:EMACSLOADPATH = "$(Exec-Cask load-path)"
+        $Env:Path = "$(Exec-Cask path)"
+        & $cmd @args
+   } finally {
+        $Env:EMACSLOADPATH = $emacsLoadPath
+        $Env:Path = $path
+    }
+}
+
+function Exec-Emacs {
+    Exec-Command emacs @args
+}
+
+$caskCmd = $args[0]
+
+if ($caskCmd -eq "emacs") {
+    Exec-Emacs $args[1..($args.Count - 1)]
+} elseif ($caskCmd -eq "exec") {
+    Exec-Command $args[1..($args.Count - 1)]
+} else {
+    Exec-Cask $args
+}

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -363,6 +363,14 @@ Commands:
   "Be verbose and show debug output."
   (setq shut-up-ignore t))
 
+;;; TODO: Allow tracing an arbitrary prefix.
+(defun cask-cli/trace ()
+  "Trace cask function calls."
+  (require 'cask-trace (expand-file-name "cask-trace" cask-directory))
+  (cask-trace-prefix "cask-")
+  (setq cask-trace-entry-p t)
+  (setq cask-trace-exit-p t))
+
 (defun cask-cli/silent ()
   "Be silent and do not print anything."
   (setq cask-cli--silent t))
@@ -411,6 +419,7 @@ Commands:
  (option "--debug" cask-cli/debug)
  (option "--path <path>" cask-cli/set-path)
  (option "--verbose" cask-cli/verbose)
+ (option "--trace" cask-cli/trace)
  (option "--silent" cask-cli/silent))
 
 (provide 'cask-cli)

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -368,12 +368,11 @@ Commands:
   "Trace functions whose name starts with one of PREFIXES.
 If PREFIXES are not specified, 'cask-' functions will be traced."
   (require 'cask-trace (expand-file-name "cask-trace" cask-directory))
+  (cask-trace-print-entry t)
+  (cask-trace-print-exit t)
   (if prefixes
-      (dolist (prefix prefixes)
-        (cask-trace-prefix prefix))
-    (cask-trace-prefix "cask-"))
-  (setq cask-trace-entry-p t)
-  (setq cask-trace-exit-p t))
+      (mapc #'cask-trace-prefix prefixes)
+    (cask-trace-prefix "cask-")))
 
 (defun cask-cli/silent ()
   "Be silent and do not print anything."

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -363,16 +363,15 @@ Commands:
   "Be verbose and show debug output."
   (setq shut-up-ignore t))
 
-;;; TODO: Allow tracing an arbitrary prefix.
-(defun cask-cli/trace ()
-  "Trace cask function calls."
+;; On macOS at least, `error' and `signal' can be traced, which is very useful.
+(defun cask-cli/trace (&rest prefixes)
+  "Trace functions whose name starts with one of PREFIXES.
+If PREFIXES are not specified, 'cask-' functions will be traced."
   (require 'cask-trace (expand-file-name "cask-trace" cask-directory))
-  (cask-trace-prefix "cask-")
-  (cask-trace-prefix "f-")
-  (cask-trace-prefix "package-")
-  ;; FIX: `error' and `signal' don't seem to be traceable on Windows.
-  (dolist (f '(error signal get-buffer-process write-region))
-    (trace-function f))
+  (if prefixes
+      (dolist (prefix prefixes)
+        (cask-trace-prefix prefix))
+    (cask-trace-prefix "cask-"))
   (setq cask-trace-entry-p t)
   (setq cask-trace-exit-p t))
 
@@ -424,7 +423,7 @@ Commands:
  (option "--debug" cask-cli/debug)
  (option "--path <path>" cask-cli/set-path)
  (option "--verbose" cask-cli/verbose)
- (option "--trace" cask-cli/trace)
+ (option "--trace [*]" cask-cli/trace)
  (option "--silent" cask-cli/silent))
 
 (provide 'cask-cli)

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -368,6 +368,11 @@ Commands:
   "Trace cask function calls."
   (require 'cask-trace (expand-file-name "cask-trace" cask-directory))
   (cask-trace-prefix "cask-")
+  (cask-trace-prefix "f-")
+  (cask-trace-prefix "package-")
+  ;; FIX: These 2 don't seem to be traceable on Windows.
+  (dolist (f '(error signal))
+    (trace-function f))
   (setq cask-trace-entry-p t)
   (setq cask-trace-exit-p t))
 

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -370,8 +370,8 @@ Commands:
   (cask-trace-prefix "cask-")
   (cask-trace-prefix "f-")
   (cask-trace-prefix "package-")
-  ;; FIX: These 2 don't seem to be traceable on Windows.
-  (dolist (f '(error signal))
+  ;; FIX: `error' and `signal' don't seem to be traceable on Windows.
+  (dolist (f '(error signal get-buffer-process write-region))
     (trace-function f))
   (setq cask-trace-entry-p t)
   (setq cask-trace-exit-p t))

--- a/cask-trace.el
+++ b/cask-trace.el
@@ -1,0 +1,50 @@
+(require 'trace)
+(require 'nadvice)
+(require 's)
+
+(defvar cask-trace-entry-p nil)
+(defvar cask-trace-exit-p nil)
+
+(define-advice trace-entry-message (:around (f &rest args) cask-print)
+  (let ((msg (apply f args)))
+    (when cask-trace-entry-p
+      (message "[trace] %s" (s-trim-right msg)))
+    msg))
+
+(define-advice trace-exit-message (:around (f &rest args) cask-print)
+  (let ((msg (apply f args)))
+    (when cask-trace-exit-p
+      (message "[trace] %s" (s-trim-right msg)))
+    msg))
+
+;; FIX: These APIs are cleaner, but results in 'Variable binding depth exceeds max-specpdl-size'.
+;; (defun cask-print-trace-message (f &rest args)
+;;   (let ((msg (apply f args)))
+;;     (message (s-trim-right msg))
+;;     msg))
+;;
+;; (defun cask-trace-entry (enabled)
+;;   (if enabled
+;;       (advice-add 'trace-entry-message :around #'cask-print-trace-message)
+;;     (advice-remove 'trace-entry-message #'cask-print-trace-message)))
+;;
+;; (defun cask-trace-exit (enabled)
+;;   (if enabled
+;;       (advice-add 'trace-exit-message :around #'cask-print-trace-message)
+;;     (advice-remove 'trace-exit-message #'cask-print-trace-message)))
+
+(defun cask-trace-prefix (prefix)
+  (mapatoms
+   (lambda (s)
+     (when (and (string-prefix-p prefix (symbol-name s))
+                (functionp s))
+       (trace-function s)))))
+
+(defun cask-untrace-prefix (prefix)
+  (mapatoms
+   (lambda (s)
+     (when (and (string-prefix-p prefix (symbol-name s))
+                (functionp s))
+       (untrace-function s)))))
+
+(provide 'cask-trace)

--- a/cask-trace.el
+++ b/cask-trace.el
@@ -1,50 +1,64 @@
+;;; cask-trace.el --- Cask: Tracing function calls  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019 Johan Andersson
+
+;; Author: Tuấn-Anh Nguyễn <ubolonton@gmail.com>
+;; Maintainer: Johan Andersson <johan.rejeep@gmail.com>
+;; URL: http://github.com/cask/cask
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Cask's tracing support, for troubleshooting non-interactive environments.
+
+;;; Code:
+
 (require 'trace)
 (require 'nadvice)
 (require 's)
 
-(defvar cask-trace-entry-p nil)
-(defvar cask-trace-exit-p nil)
-
-(define-advice trace-entry-message (:around (f &rest args) cask-print)
+(defun cask-trace-print-message (f &rest args)
   (let ((msg (apply f args)))
-    (when cask-trace-entry-p
-      (message "[trace] %s" (s-trim-right msg)))
+    (message "[trace] %s" (s-trim-right msg))
     msg))
 
-(define-advice trace-exit-message (:around (f &rest args) cask-print)
-  (let ((msg (apply f args)))
-    (when cask-trace-exit-p
-      (message "[trace] %s" (s-trim-right msg)))
-    msg))
+(defun cask-trace-print-entry (enabled)
+  (if enabled
+      (advice-add 'trace-entry-message :around #'cask-trace-print-message)
+    (advice-remove 'trace-entry-message #'cask-trace-print-message)))
 
-;; FIX: These APIs are cleaner, but results in 'Variable binding depth exceeds max-specpdl-size'.
-;; (defun cask-print-trace-message (f &rest args)
-;;   (let ((msg (apply f args)))
-;;     (message (s-trim-right msg))
-;;     msg))
-;;
-;; (defun cask-trace-entry (enabled)
-;;   (if enabled
-;;       (advice-add 'trace-entry-message :around #'cask-print-trace-message)
-;;     (advice-remove 'trace-entry-message #'cask-print-trace-message)))
-;;
-;; (defun cask-trace-exit (enabled)
-;;   (if enabled
-;;       (advice-add 'trace-exit-message :around #'cask-print-trace-message)
-;;     (advice-remove 'trace-exit-message #'cask-print-trace-message)))
+(defun cask-trace-print-exit (enabled)
+  (if enabled
+      (advice-add 'trace-exit-message :around #'cask-trace-print-message)
+    (advice-remove 'trace-exit-message #'cask-trace-print-message)))
+
+(defun cask-trace--map-prefix (prefix function)
+  (mapatoms
+   (lambda (s)
+     (when (and (string-prefix-p prefix (symbol-name s))
+                (functionp s)
+                (not (eq s #'cask-trace-print-message)))
+       (funcall function s)))))
 
 (defun cask-trace-prefix (prefix)
-  (mapatoms
-   (lambda (s)
-     (when (and (string-prefix-p prefix (symbol-name s))
-                (functionp s))
-       (trace-function s)))))
+  (cask-trace--map-prefix prefix #'trace-function))
 
 (defun cask-untrace-prefix (prefix)
-  (mapatoms
-   (lambda (s)
-     (when (and (string-prefix-p prefix (symbol-name s))
-                (functionp s))
-       (untrace-function s)))))
+  (cask-trace--map-prefix prefix #'untrace-function))
 
 (provide 'cask-trace)
+;;; cask-trace.el ends here

--- a/cask.el
+++ b/cask.el
@@ -1019,7 +1019,9 @@ a directory specified by `cask-dist-path' in the BUNDLE path."
                   :files patterns
                   :dir path))
             (package-build-working-dir path)
-            (package-build-archive-dir target-dir))
+            (package-build-archive-dir target-dir)
+            (coding-system-for-write 'prefer-utf-8)
+            (buffer-file-coding-system 'prefer-utf-8))
         (package-build--package rcp version)))))
 
 (provide 'cask)

--- a/cask.el
+++ b/cask.el
@@ -1020,7 +1020,9 @@ a directory specified by `cask-dist-path' in the BUNDLE path."
                   :dir path))
             (package-build-working-dir path)
             (package-build-archive-dir target-dir)
-            (buffer-file-coding-system 'prefer-utf-8))
+            ;; This assumes only package files are written. For these files
+            ;; there's practically no reason to use any other coding.
+            (buffer-file-coding-system 'utf-8-unix))
         (package-build--package rcp version)))))
 
 (provide 'cask)

--- a/cask.el
+++ b/cask.el
@@ -1020,7 +1020,6 @@ a directory specified by `cask-dist-path' in the BUNDLE path."
                   :dir path))
             (package-build-working-dir path)
             (package-build-archive-dir target-dir)
-            (coding-system-for-write 'prefer-utf-8)
             (buffer-file-coding-system 'prefer-utf-8))
         (package-build--package rcp version)))))
 

--- a/test/cask.Tests.ps1
+++ b/test/cask.Tests.ps1
@@ -1,0 +1,87 @@
+﻿$here = Join-Path (Get-Item $MyInvocation.MyCommand.Path).Directory.Parent.FullName "bin"
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+
+. "$here\$sut"
+
+# These tests need Pester, the popular Powershell testing framework
+# From the project root, run: Invoke-Pester -EnableExit .\test\
+# This will create a top-level .cask dir for the whole run and abandon it on exit
+# TODO: environment modification and restoration
+# TODO: Exec-Cask
+
+Describe "Exec-Command Unit" {
+    function Foo {}
+    function emacs {}
+    Context "With fake receivers" {
+        Get-Command emacs | Select-Object -ExpandProperty CommandType | Should Be "Function"
+        Mock Foo {return [psCustomObject]@{args = $args}}
+        Mock emacs {return [psCustomObject]@{args = $args}}
+        It "sees two args" {
+            $result = cask exec Foo one two
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "two"
+            $result.args.Count | Should Be 2
+        }
+        Assert-MockCalled Foo -Times 1
+        It "sees two args emacs" {
+            $result = cask emacs one two
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "two"
+            $result.args.Count | Should Be 2
+        }
+        Assert-MockCalled emacs -Times 1
+        It "sees one arg" {
+            $result = cask exec foo one
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "one"
+            $result.args[1] | Should Be $null
+            $result.args.Count | Should Be 1
+        }
+        Assert-MockCalled Foo -Times 2
+        It "sees one arg emacs" {
+            $result = cask emacs one
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "one"
+            $result.args[1] | Should Be $null
+            $result.args.Count | Should Be 1
+        }
+        Assert-MockCalled emacs -Times 2
+        It "sees no args" {
+            $result = cask exec foo
+            $result.args[0] | Should Be $null
+            $result.args.Count | Should Be 0
+        }
+        Assert-MockCalled Foo -Times 3
+        It "sees no args emacs" {
+            $result = cask emacs
+            $result.args[0] | Should Be $null
+            $result.args.Count | Should Be 0
+        }
+        Assert-MockCalled emacs -Times 3
+    }
+}
+
+Describe "Exec-Command Functional" {
+    # Sanity first
+    Get-Command emacs | Select-Object -ExpandProperty CommandType | Should Be "Application"
+    Context "Exit status exported to invoker" {
+        It "exits zero" {
+            cask exec emacs -Q --batch --eval '(kill-emacs 0)'
+            $? | Should Be $true
+        }
+        It "exits nonzero" {
+            { cask exec emacs -Q --batch --eval '(kill-emacs 1)' } | Should Throw
+        }
+    }
+    Context "Params passed to subproc" {
+        It "prints args with exec" {
+            $result = cask exec emacs -Q --batch --eval '(princ command-line-args)'
+            $result | Should BeLike "(*\bin\emacs.exe --eval (princ command-line-args))"
+        }
+        It "prints args without exec" {
+            $result = cask emacs -Q --batch --eval '(princ command-line-args)'
+            $result | Should BeLike "(*\bin\emacs.exe --eval (princ command-line-args))"
+        }
+    }
+}
+


### PR DESCRIPTION
Hi,

Not sure if you remember me, but I corresponded with you briefly about this last summer. Apologies if you actually *did* get around to trying it out and were too horrified to respond. :vomiting_face: 

Anyway, to refresh your memory, I really want cask to propagate bad exits from Emacs when tests fail. This patch does that, though there are probably better ways. I *think* pester comes preloaded on azure runners, but don't quote me.

Side question: are you planning on maintaining this as a fork? If so, that'd be great because it seems like the upstream project is pretty sleepy/dead.  Also (assuming yes), would you be willing to entertain removing the python dependency completely?

Thanks!

BTW, I'm a recent convert to tree-sitter (can't imagine living without it)!